### PR TITLE
Added a tool (get_item_history) to get item change logs via histories API

### DIFF
--- a/src/mcp_server/drivers/pagoda.py
+++ b/src/mcp_server/drivers/pagoda.py
@@ -276,17 +276,17 @@ def get_item_detail_api(
     return ItemDetail(**resp.json())
 
 
-def get_item_histories_api(
+def get_item_history_api(
     endpoint: str,
     token: str,
     item_id: int,
     log_prefix: str = "",
 ) -> list[ItemHistory]:
     """
-    This retrieves item histories from the Pagoda API.
+    This retrieves item history from the Pagoda API.
     e.g. https://airone.dmmlabs.jp/entry/api/v2/533972/histories/
     """
-    Logger.debug(log_prefix + f"get_item_histories_api(Input) item_id={item_id}")
+    Logger.debug(log_prefix + f"get_item_history_api(Input) item_id={item_id}")
     results = []
     page = 1
 
@@ -304,7 +304,7 @@ def get_item_histories_api(
             break
         page += 1
 
-    Logger.debug(log_prefix + f"get_item_histories_api(Output) {results}")
+    Logger.debug(log_prefix + f"get_item_history_api(Output) {results}")
     return [ItemHistory(**result) for result in results]
 
 

--- a/src/mcp_server/drivers/pagoda.py
+++ b/src/mcp_server/drivers/pagoda.py
@@ -54,6 +54,27 @@ class AdvancedSearchResult(BaseModel):
     values: list[AdvancedSearchResultItem]
 
 
+class ItemHistoryParentAttr(BaseModel):
+    id: int
+    name: str
+
+
+class ItemHistoryValue(BaseModel):
+    as_string: str | None = None
+    as_object: dict | None = None
+
+
+class ItemHistory(BaseModel):
+    id: int
+    type: int
+    created_time: str
+    created_user: str
+    curr_value: ItemHistoryValue
+    prev_value: ItemHistoryValue | None
+    prev_id: int | None
+    parent_attr: ItemHistoryParentAttr
+
+
 def request_to_airone(
     method: Callable, url: str, token: str, params: dict | None, data: dict | None
 ) -> requests.Response:
@@ -253,6 +274,38 @@ def get_item_detail_api(
 
     Logger.debug(log_prefix + f"get_item_detail_api(Output) {resp.json()}")
     return ItemDetail(**resp.json())
+
+
+def get_item_histories_api(
+    endpoint: str,
+    token: str,
+    item_id: int,
+    log_prefix: str = "",
+) -> list[ItemHistory]:
+    """
+    This retrieves item histories from the Pagoda API.
+    e.g. https://airone.dmmlabs.jp/entry/api/v2/533972/histories/
+    """
+    Logger.debug(log_prefix + f"get_item_histories_api(Input) item_id={item_id}")
+    results = []
+    page = 1
+
+    while True:
+        resp = request_get(
+            url=endpoint + f"/entry/api/v2/{item_id}/histories/",
+            params={"page": str(page)},
+            token=token,
+        )
+        if resp.status_code != 200:
+            raise RuntimeError(f"Request failed /entry/api/v2/{item_id}/histories/")
+        for result in resp.json()["results"]:
+            results.append(result)
+        if resp.json()["next"] is None:
+            break
+        page += 1
+
+    Logger.debug(log_prefix + f"get_item_histories_api(Output) {results}")
+    return [ItemHistory(**result) for result in results]
 
 
 def search_item_api(

--- a/src/mcp_server/tools/common.py
+++ b/src/mcp_server/tools/common.py
@@ -5,7 +5,7 @@ from mcp.server.fastmcp import Context
 from mcp_server.drivers.pagoda import (
     advanced_search_api,
     get_item_detail_api,
-    get_item_histories_api,
+    get_item_history_api,
     get_item_list_api,
     get_model_detail_api,
     get_model_list_api,
@@ -173,18 +173,18 @@ def advanced_search(
     return json.dumps(result.model_dump())
 
 
-def get_item_histories(item_id: int, ctx: Context) -> str:
-    """get item histories"""
+def get_item_history(item_id: int, ctx: Context) -> str:
+    """get item history"""
     endpoint, token = get_backend_param(ctx)
 
-    histories = get_item_histories_api(
+    history = get_item_history_api(
         endpoint=endpoint,
         token=token,
         item_id=item_id,
         log_prefix=get_prefix(ctx),
     )
 
-    return json.dumps([history.model_dump() for history in histories])
+    return json.dumps([h.model_dump() for h in history])
 
 
 COMMON_LIST = [
@@ -194,5 +194,5 @@ COMMON_LIST = [
     get_item_detail,
     search_item,
     advanced_search,
-    get_item_histories,
+    get_item_history,
 ]

--- a/src/mcp_server/tools/common.py
+++ b/src/mcp_server/tools/common.py
@@ -16,8 +16,7 @@ from mcp_server.model import AdvancedSearchAttrInfo
 
 # FIXME: This refers PagodaDriver
 class Pagoda:
-    """シングルトンパターンを使用したPagodaクライアントクラス"""
-
+    """Use singleton class of design pattern"""
     _instance: Optional["Pagoda"] = None
 
     def __init__(self):
@@ -27,14 +26,14 @@ class Pagoda:
 
     @classmethod
     def get_instance(cls) -> "Pagoda":
-        """シングルトンインスタンスを取得"""
+        """get singleton class"""
         if cls._instance is None:
             cls._instance = cls()
         return cls._instance
 
     @classmethod
     def initialize(cls, endpoint: str, token: str, is_bearer: bool) -> "Pagoda":
-        """エンドポイントとトークンでPagodaを初期化"""
+        """initialize each attributes"""
         instance = cls.get_instance()
         instance.endpoint = endpoint
         instance.token = token

--- a/src/mcp_server/tools/common.py
+++ b/src/mcp_server/tools/common.py
@@ -18,6 +18,7 @@ from mcp_server.model import AdvancedSearchAttrInfo
 # FIXME: This refers PagodaDriver
 class Pagoda:
     """Use singleton class of design pattern"""
+
     _instance: Optional["Pagoda"] = None
 
     def __init__(self):

--- a/src/mcp_server/tools/common.py
+++ b/src/mcp_server/tools/common.py
@@ -5,6 +5,7 @@ from mcp.server.fastmcp import Context
 from mcp_server.drivers.pagoda import (
     advanced_search_api,
     get_item_detail_api,
+    get_item_histories_api,
     get_item_list_api,
     get_model_detail_api,
     get_model_list_api,
@@ -172,6 +173,20 @@ def advanced_search(
     return json.dumps(result.model_dump())
 
 
+def get_item_histories(item_id: int, ctx: Context) -> str:
+    """get item histories"""
+    endpoint, token = get_backend_param(ctx)
+
+    histories = get_item_histories_api(
+        endpoint=endpoint,
+        token=token,
+        item_id=item_id,
+        log_prefix=get_prefix(ctx),
+    )
+
+    return json.dumps([history.model_dump() for history in histories])
+
+
 COMMON_LIST = [
     get_model_list,
     get_model_detail,
@@ -179,4 +194,5 @@ COMMON_LIST = [
     get_item_detail,
     search_item,
     advanced_search,
+    get_item_histories,
 ]


### PR DESCRIPTION
## Execution Result
Here is a result of new tool `get_item_history`.
<img width="1083" height="512" alt="スクリーンショット 2026-04-23 19 06 53" src="https://github.com/user-attachments/assets/e907656f-3ca7-4864-84ca-0739f95ce87d" />

```
[
  {
    "id": 20436346,
    "type": 2,
    "created_time": "2026-02-24T04:40:55.339101+09:00",
    "created_user": "user",
    "curr_value": {
      "as_string": "bar",
      "as_object": null
    },
    "prev_value": {
      "as_string": "puyo",
      "as_object": null
    },
    "prev_id": 19436431,
    "parent_attr": {
      "id": 2594282,
      "name": "attr1"
    }
  },
  {
    "id": 19436431,
    "type": 2,
    "created_time": "2025-04-16T19:39:29.474736+09:00",
    "created_user": "user",
    "curr_value": {
      "as_string": "puyo",
      "as_object": null
    },
    "prev_value": {
      "as_string": "fuga",
      "as_object": null
    },
    "prev_id": 16886790,
    "parent_attr": {
      "id": 2594282,
      "name": "attr1"
    }
  },
  ...
]
```
